### PR TITLE
session issue

### DIFF
--- a/ZPHP/Session/Swoole.php
+++ b/ZPHP/Session/Swoole.php
@@ -22,9 +22,6 @@ class Swoole
 
     public static function start($sessionType, $config)
     {
-        if (null !== self::$_sid) {
-            return;
-        }
         //判断参数里是否有sessid
         if (empty($config)) {
             $config = ZConfig::get('session');


### PR DESCRIPTION
保存变量到 $_SESSION里面去， 你第一次初始化到数据到$_SESSION全部变量， 第二个登录， 直接把你的覆盖了       ， 但是你第二次访问， return null， 你的数据就是第二个人的数据了， 你就会被他覆盖掉 
if (null !== self::$_sid) { 
            return;
        }